### PR TITLE
Change impact_reports_serializer to use player: instead of name:

### DIFF
--- a/app/serializers/v1/impact_report_serializer.rb
+++ b/app/serializers/v1/impact_report_serializer.rb
@@ -1,6 +1,10 @@
 module V1
   class ImpactReportSerializer < ActiveModel::Serializer
-    attributes :name, :first_score, :highest_score, :number_of_playthroughs, :total_time_spent
+    attributes :player, :first_score, :highest_score, :number_of_playthroughs, :total_time_spent
+
+    def player
+      object.name
+    end
 
     def first_score
       object.playthroughs.first.score

--- a/spec/requests/impact_reports_spec.rb
+++ b/spec/requests/impact_reports_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "v1/impact_reports" do
 
       expect(response).to be_successful
       expect(response.body).to eq([{
-        name: playthrough.player.name,
+        player: playthrough.player.name,
         first_score: playthrough.score,
         highest_score: playthrough.score,
         number_of_playthroughs: 1,
         total_time_spent: "01:00:00"
       },
       {
-        name: playthrough_2.player.name,
+        player: playthrough_2.player.name,
         first_score: playthrough_2.score,
         highest_score: playthrough_2.score,
         number_of_playthroughs: 1,


### PR DESCRIPTION
why: so that the naming conventions between the report/summary endpoints are consistent